### PR TITLE
docs: add `Netzo`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ The following frameworks provide Fresh integration.
 
 - [Deco](https://github.com/deco-cx/deco) - Open-Source web editor based on Preact, Tailwind and TypeScript. The other side of code.
 - [kview](https://github.com/kitsonk/kview) - A web interface for viewing Deno KV stores.
-- [Netzo](https://netzo.io) - The smartest way to build business web apps (based on Deno, Fresh, UnoCSS and ShadcnUI)
+- [Netzo](https://netzo.io) - Build business web apps fast, with less resources with an opinionated fresh meta-framework and development platform.
 
 ## Related lists
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ The following frameworks provide Fresh integration.
 
 - [Deco](https://github.com/deco-cx/deco) - Open-Source web editor based on Preact, Tailwind and TypeScript. The other side of code.
 - [kview](https://github.com/kitsonk/kview) - A web interface for viewing Deno KV stores.
+- [Netzo](https://netzo.io) - The smartest way to build business web apps (based on Deno, Fresh, UnoCSS and ShadcnUI)
 
 ## Related lists
 


### PR DESCRIPTION
Netzo is the smartest way to build business web apps, in essence:

- [Netzo framework](https://github.com/netzo/netzo): an open-source, opinionated yet flexible fresh-based meta-framework that makes building custom business web apps fast.
- [Netzo platform](https://netzo.io): a platform to ease development, deployment, management and roll-out of these business web apps within organizations.

We are building on Deno+Fresh and would appreciate being added to the list. Thanks!